### PR TITLE
Update jinja2_hamlpy.py

### DIFF
--- a/jinja2_hamlpy.py
+++ b/jinja2_hamlpy.py
@@ -1,16 +1,20 @@
-from jinja2.ext import Extension
-from jinja2 import TemplateSyntaxError
+import os.path
+
 from hamlpy.hamlpy import Compiler
-import os
+from jinja2 import TemplateSyntaxError
+from jinja2.ext import Extension
+
 
 class HamlPyExtension(Extension):
+    
+    HAML_EXTENSIONS = ('.haml', )
+    
     def preprocess(self, source, name, filename=None):
-        if name is None or os.path.splitext(name)[1] not in ('.haml',):
+        if not name or os.path.splitext(name)[1] not in self.HAML_EXTENSIONS:
             return source
 
-	compiler = Compiler()
+        compiler = Compiler()
         try:
             return compiler.process(source)
         except Exception, e:
             raise TemplateSyntaxError(e, None, name=name, filename=filename)
-


### PR DESCRIPTION
- Modifies style to match PEP8
- Uses `not name` instead of `name is None` ('' should be an invalid name as well, right?)
- Refactors available HAML file extensions to a class-level variable.
