### PR TITLE
remove "black magic" workaround for older setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,6 @@
 import os
 from setuptools import setup, find_packages
 
-# This is to disable the 'black magic' surrounding versioned repositories... Terrible!
-from setuptools.command import sdist
-del sdist.finders[:]
-
 # Utility function to read the README file.
 # Used for the long_description.  It's nice, because now 1) we have a top level
 # README file and 2) it's easier to type in the README file than to put a raw


### PR DESCRIPTION
Newest setuptools doesn't provide "finders" attribute, so setup.py cannot execute. 

See https://github.com/kmike/nltk/commit/f34b390147ca439d303899fa407be5c096499868 for source of fix.

(If you don't agree with the removal of the lines, maybe some conditions or a try/except block will workaround the removal of the workaround for older setuptools versions.)
